### PR TITLE
fix: make clean command works (do nothing) when branch list to delete is empty.

### DIFF
--- a/internal/git/cli_actor.go
+++ b/internal/git/cli_actor.go
@@ -23,6 +23,10 @@ func (g *cliActor) FetchAll(ctx context.Context) error {
 }
 
 func (g *cliActor) DeleteBranches(ctx context.Context, branches []Branch) error {
+	if len(branches) == 0 {
+		return nil
+	}
+
 	args := []string{"branch", "-d"}
 	for _, branch := range branches {
 		args = append(args, branch.Name)


### PR DESCRIPTION
## Changes
<!-- Describe the changes in this PR concisely. -->
- make `#cliActor.DeleteBranches` do not exec command on empty branch list.

## Reason/Purpose of Change
<!-- Explain why this change is needed or its purpose. -->
- To fix the issue which`clean` command throws error when brance list to delete is empty.

## Additional Notes
<!-- Provide additional information for reviewers (test procedures, screenshots, related issue numbers, etc.) -->


## Todo
<!-- 
- [ ] Checklist (Edit as needed)
-->
