### PR TITLE
fix!: make branch deleted even if it not merged

### DIFF
--- a/internal/git/cli_actor.go
+++ b/internal/git/cli_actor.go
@@ -27,7 +27,7 @@ func (g *cliActor) DeleteBranches(ctx context.Context, branches []Branch) error 
 		return nil
 	}
 
-	args := []string{"branch", "-d"}
+	args := []string{"branch", "-D"}
 	for _, branch := range branches {
 		args = append(args, branch.Name)
 	}


### PR DESCRIPTION
## Changes
- make branch deleted even if it not merged when execute command

## Reason/Purpose of Change
<!-- Explain why this change is needed or its purpose. -->
- If some branch is not merged, then command was returning error, caused by `git branch -d` command error internally
- So, it changes to execute `git branch -D` instead to be able to delete for this case.

## Additional Notes
<!-- Provide additional information for reviewers (test procedures, screenshots, related issue numbers, etc.) -->


## Todo
<!-- 
- [ ] Checklist (Edit as needed)
-->
[ ] Add filter to exclude not merged branches
